### PR TITLE
41 us 030601

### DIFF
--- a/app/src/androidTest/java/com/example/pygmyhippo/organiser/PostEventFragmentTesting.java
+++ b/app/src/androidTest/java/com/example/pygmyhippo/organiser/PostEventFragmentTesting.java
@@ -1,26 +1,21 @@
 package com.example.pygmyhippo.organiser;
-import com.example.pygmyhippo.R;
+
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-
-import static androidx.test.espresso.action.ViewActions.click;
-
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import android.net.Uri;
-
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import com.example.pygmyhippo.MainActivity;
+import com.example.pygmyhippo.R;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/app/src/main/java/com/example/pygmyhippo/MainActivity.java
+++ b/app/src/main/java/com/example/pygmyhippo/MainActivity.java
@@ -20,6 +20,7 @@ import com.example.pygmyhippo.common.Account;
 import com.example.pygmyhippo.common.OnRoleSelectedListener;
 import com.example.pygmyhippo.database.DBOnCompleteFlags;
 import com.example.pygmyhippo.database.DBOnCompleteListener;
+import com.example.pygmyhippo.databinding.AdminMainActivityNavigationBinding;
 import com.example.pygmyhippo.databinding.OrganiserMainActivityNagivationBinding;
 import com.example.pygmyhippo.databinding.UserMainActivityNagivationBinding;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
@@ -35,6 +36,7 @@ public class MainActivity extends AppCompatActivity implements OnRoleSelectedLis
     final int PERMISSION_REQUEST_CODE =112;
     private OrganiserMainActivityNagivationBinding organiserBinder;
     private UserMainActivityNagivationBinding userBinder;
+    private AdminMainActivityNavigationBinding adminBinding;
     private MainActivityDB dbHandler;
     private Account signedInAccount;
 
@@ -198,6 +200,16 @@ public class MainActivity extends AppCompatActivity implements OnRoleSelectedLis
         NavigationUI.setupWithNavController(navView, navController);
     }
 
+
+    private void setupNavControllerAdmin(BottomNavigationView navView, Bundle bundle) {
+        AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
+                R.id.admin_all_events, R.id.admin_all_images, R.id.admin_all_profiles)
+                .build();
+        NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
+        navController.setGraph(R.navigation.admin_mobile_navigation, bundle);
+        NavigationUI.setupWithNavController(navView, navController);
+    }
+
     /**
      * Callback called when DB queries complete.
      * @param docs - Documents retrieved from DB (if it was a get query).
@@ -280,9 +292,14 @@ public class MainActivity extends AppCompatActivity implements OnRoleSelectedLis
                 setContentView(organiserBinder.getRoot());
                 setupNavControllerOrganiser(organiserBinder.navView, bundle);
                 break;
+            case admin:
+                Log.d("MainActivity", "Setting navigation for admin.");
+                adminBinding = AdminMainActivityNavigationBinding.inflate(getLayoutInflater());
+                setContentView(adminBinding.getRoot());
+                setupNavControllerAdmin(adminBinding.navView, bundle);
+                break;
             default:
                 Log.d("MainActivity", String.format("Unknown role (%s)", account.getCurrentRole().value));
-                // needs a case for admin
                 break;
         }
     }

--- a/app/src/main/java/com/example/pygmyhippo/MainActivity.java
+++ b/app/src/main/java/com/example/pygmyhippo/MainActivity.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 
 /**
  * Main Activity for our android app
+ *
+ * FIXME: Double account creation when a new device tries to open the app.
  * @author Jennifer, Griffin
  */
 public class MainActivity extends AppCompatActivity implements OnRoleSelectedListener, DBOnCompleteListener<Account> {

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
@@ -3,27 +3,74 @@ package com.example.pygmyhippo.admin;
 import android.net.Uri;
 import android.util.Log;
 
+import com.example.pygmyhippo.common.Account;
+import com.example.pygmyhippo.common.Event;
 import com.example.pygmyhippo.common.Image;
 import com.example.pygmyhippo.database.DBHandler;
 import com.example.pygmyhippo.database.DBOnCompleteFlags;
 import com.example.pygmyhippo.database.DBOnCompleteListener;
+import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
 
 public class AllImageDB extends DBHandler {
     public void getImageDownloadUrl(Image image, DBOnCompleteListener<Uri> listener) {
-        StorageReference ref = storage.getReferenceFromUrl(image.getUrl());
-        ref.getDownloadUrl().addOnCompleteListener(task -> {
-            if (task.isSuccessful()) {
-                Log.d("DB", String.format("Found image at %s", image.getUrl()));
-                Uri uri = task.getResult();
-                ArrayList<Uri> results = new ArrayList<>();
-                results.add(uri);
-                listener.OnComplete(results, 0, DBOnCompleteFlags.SUCCESS.value);
-            } else {
-                Log.d("DB", String.format("Image download failed for %s", image.getUrl()));
-            }
-        });
+        Log.d("DB", String.format("Getting storage reference for image url %s", image.getUrl()));
+        try {
+            StorageReference ref = storage.getReferenceFromUrl(image.getUrl());
+            ref.getDownloadUrl().addOnCompleteListener(task -> {
+                if (task.isSuccessful()) {
+                    Log.d("DB", String.format("Found image at %s", image.getUrl()));
+                    Uri uri = task.getResult();
+                    ArrayList<Uri> results = new ArrayList<>();
+                    results.add(uri);
+                    listener.OnComplete(results, 0, DBOnCompleteFlags.SUCCESS.value);
+                } else {
+                    Log.d("DB", String.format("Image download failed for %s", image.getUrl()));
+                }
+            });
+        } catch (IllegalArgumentException e) {
+            Log.d("DB", String.format("IllegalArgumentException for url %s", image.getUrl()));
+            listener.OnComplete(new ArrayList<>(), 0, DBOnCompleteFlags.ERROR.value);
+        }
+    }
+
+    public void getAccounts(int limit, DBOnCompleteListener<Object> listener) {
+        db.collection("Accounts")
+            .whereNotEqualTo("profilePicture", "")
+            .limit(limit)
+            .get()
+            .addOnCompleteListener(task -> {
+                if (task.isSuccessful()) {
+                    QuerySnapshot queryResult = task.getResult();
+                    Log.d("DB", String.format("%d Accounts with non-empty profilePicture are fetched.", queryResult.size()));
+                    ArrayList<Account> accountList = new ArrayList<>();
+                    queryResult.forEach(doc -> accountList.add(doc.toObject(Account.class)));
+                    listener.OnComplete(new ArrayList<>(accountList), 1, DBOnCompleteFlags.SUCCESS.value);
+                } else {
+                    Log.d("DB", "Error in getting accounts for All Images");
+                    listener.OnComplete(new ArrayList<>(), 1, DBOnCompleteFlags.ERROR.value);
+                }
+            });
+    }
+
+    public void getEvents(int limit, DBOnCompleteListener<Object> listener) {
+        db.collection("Events")
+            .whereNotEqualTo("eventPoster", "")
+            .limit(limit)
+            .get()
+            .addOnCompleteListener(task -> {
+                if (task.isSuccessful()) {
+                    QuerySnapshot queryResult = task.getResult();
+                    Log.d("DB", String.format("%d Events with non-empty profilePicture are fetched.", queryResult.size()));
+                    ArrayList<Event> eventList = new ArrayList<>();
+                    queryResult.forEach(doc -> eventList.add(doc.toObject(Event.class)));
+                    listener.OnComplete(new ArrayList<>(eventList), 2, DBOnCompleteFlags.SUCCESS.value);
+                } else {
+                    Log.d("DB", "Error in getting events for All Images");
+                    listener.OnComplete(new ArrayList<>(), 2, DBOnCompleteFlags.ERROR.value);
+                }
+            });
     }
 }

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
@@ -1,3 +1,10 @@
+/**
+ * AllImageDB
+ *
+ * DBHandler for AllImagesFragment and ImageViewHolder.
+ */
+
+
 package com.example.pygmyhippo.admin;
 
 import android.net.Uri;
@@ -14,7 +21,19 @@ import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
 
+/**
+ * DBHandler for AllImagesFragment.
+ *
+ * Handles getting images from firebase storage, getting accounts and events from firestore.
+ *
+ * TODO: Need redesign for better compatibility with RecyclerView pagination in AllImagesFragment for getting accounts and events.
+ */
 public class AllImageDB extends DBHandler {
+    /**
+     * Gets a long-live download uris for Picasso to get image from Firebase Storage.
+     * @param image Image class with gs:// link to Firebase Storage image.
+     * @param listener DBOnCompleteListener to call when query completes.
+     */
     public void getImageDownloadUrl(Image image, DBOnCompleteListener<Uri> listener) {
         Log.d("DB", String.format("Getting storage reference for image url %s", image.getUrl()));
         try {
@@ -36,6 +55,11 @@ public class AllImageDB extends DBHandler {
         }
     }
 
+    /**
+     * Gets accounts from Firestore with non-empty string in profilePicture field.
+     * @param limit Limit on number of accounts to get in query.
+     * @param listener DBOnCompleteListener to call when query completes.
+     */
     public void getAccounts(int limit, DBOnCompleteListener<Object> listener) {
         db.collection("Accounts")
             .whereNotEqualTo("profilePicture", "")
@@ -55,6 +79,11 @@ public class AllImageDB extends DBHandler {
             });
     }
 
+    /**
+     * Gets accounts from Firestore with non-empty string in eventPoster field.
+     * @param limit Limit on number of events to get in query.
+     * @param listener DBOnCompleteListener to call when query completes.
+     */
     public void getEvents(int limit, DBOnCompleteListener<Object> listener) {
         db.collection("Events")
             .whereNotEqualTo("eventPoster", "")
@@ -63,7 +92,7 @@ public class AllImageDB extends DBHandler {
             .addOnCompleteListener(task -> {
                 if (task.isSuccessful()) {
                     QuerySnapshot queryResult = task.getResult();
-                    Log.d("DB", String.format("%d Events with non-empty profilePicture are fetched.", queryResult.size()));
+                    Log.d("DB", String.format("%d Events with non-empty eventPoster are fetched.", queryResult.size()));
                     ArrayList<Event> eventList = new ArrayList<>();
                     queryResult.forEach(doc -> eventList.add(doc.toObject(Event.class)));
                     listener.OnComplete(new ArrayList<>(eventList), 2, DBOnCompleteFlags.SUCCESS.value);

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImageDB.java
@@ -1,0 +1,29 @@
+package com.example.pygmyhippo.admin;
+
+import android.net.Uri;
+import android.util.Log;
+
+import com.example.pygmyhippo.common.Image;
+import com.example.pygmyhippo.database.DBHandler;
+import com.example.pygmyhippo.database.DBOnCompleteFlags;
+import com.example.pygmyhippo.database.DBOnCompleteListener;
+import com.google.firebase.storage.StorageReference;
+
+import java.util.ArrayList;
+
+public class AllImageDB extends DBHandler {
+    public void getImageDownloadUrl(Image image, DBOnCompleteListener<Uri> listener) {
+        StorageReference ref = storage.getReferenceFromUrl(image.getUrl());
+        ref.getDownloadUrl().addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                Log.d("DB", String.format("Found image at %s", image.getUrl()));
+                Uri uri = task.getResult();
+                ArrayList<Uri> results = new ArrayList<>();
+                results.add(uri);
+                listener.OnComplete(results, 0, DBOnCompleteFlags.SUCCESS.value);
+            } else {
+                Log.d("DB", String.format("Image download failed for %s", image.getUrl()));
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
@@ -1,0 +1,50 @@
+package com.example.pygmyhippo.admin;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+
+import com.example.pygmyhippo.R;
+import com.example.pygmyhippo.common.BaseRecyclerAdapter;
+import com.example.pygmyhippo.common.BaseViewHolder;
+import com.example.pygmyhippo.common.Image;
+import com.example.pygmyhippo.common.RecyclerClickListener;
+
+import java.util.ArrayList;
+
+public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapter.ImageViewHolder> {
+    public static class ImageViewHolder extends BaseViewHolder<Image> {
+        private ImageView imageView;
+
+        public ImageViewHolder(@NonNull View itemView) {
+            super(itemView);
+            imageView = itemView.findViewById(R.id.a_alllist_image);
+        }
+
+        @Override
+        public void setViews(Image dataclass) {
+            // TODO: Get image from firebase storage.
+        }
+    }
+
+    public AllImagesAdapter(ArrayList<Image> dataList, RecyclerClickListener listener) {
+        super(dataList, listener);
+    }
+
+    @NonNull
+    @Override
+    public ImageViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.admin_all_list_image_item, parent, false);
+        AllImagesAdapter.ImageViewHolder viewHolder = new ImageViewHolder(view);
+
+        view.setOnClickListener(v -> {
+            listener.onItemClick(viewHolder.getAdapterPosition());
+        });
+
+        return viewHolder;
+    }
+}

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
@@ -1,3 +1,9 @@
+/**
+ * AllImagesAdapter
+ *
+ * RecyclerView adapter for RecyclerView in AllImagesFragment.
+ */
+
 package com.example.pygmyhippo.admin;
 
 import android.net.Uri;
@@ -19,6 +25,9 @@ import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 
+/**
+ * Adapter for RecyclerView in AllImagesFragment.
+ */
 public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapter.ImageViewHolder> {
     public static class ImageViewHolder extends BaseViewHolder<Image> implements DBOnCompleteListener<Uri> {
         private final ImageView imageView;

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
@@ -12,12 +12,13 @@ import com.example.pygmyhippo.common.BaseRecyclerAdapter;
 import com.example.pygmyhippo.common.BaseViewHolder;
 import com.example.pygmyhippo.common.Image;
 import com.example.pygmyhippo.common.RecyclerClickListener;
+import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 
 public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapter.ImageViewHolder> {
     public static class ImageViewHolder extends BaseViewHolder<Image> {
-        private ImageView imageView;
+        private final ImageView imageView;
 
         public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -26,7 +27,9 @@ public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapte
 
         @Override
         public void setViews(Image dataclass) {
-            // TODO: Get image from firebase storage.
+            Picasso.get()
+                    .load(dataclass.getUrl())
+                    .into(imageView);
         }
     }
 

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
@@ -31,12 +31,12 @@ import java.util.ArrayList;
 public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapter.ImageViewHolder> {
     public static class ImageViewHolder extends BaseViewHolder<Image> implements DBOnCompleteListener<Uri> {
         private final ImageView imageView;
-        private final AllImageDB handler;
+        private final AllImagesDB handler;
 
         public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.a_alllist_image);
-            handler = new AllImageDB();
+            handler = new AllImagesDB();
         }
 
         @Override

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesAdapter.java
@@ -1,5 +1,6 @@
 package com.example.pygmyhippo.admin;
 
+import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,24 +13,41 @@ import com.example.pygmyhippo.common.BaseRecyclerAdapter;
 import com.example.pygmyhippo.common.BaseViewHolder;
 import com.example.pygmyhippo.common.Image;
 import com.example.pygmyhippo.common.RecyclerClickListener;
+import com.example.pygmyhippo.database.DBOnCompleteFlags;
+import com.example.pygmyhippo.database.DBOnCompleteListener;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 
 public class AllImagesAdapter extends BaseRecyclerAdapter<Image, AllImagesAdapter.ImageViewHolder> {
-    public static class ImageViewHolder extends BaseViewHolder<Image> {
+    public static class ImageViewHolder extends BaseViewHolder<Image> implements DBOnCompleteListener<Uri> {
         private final ImageView imageView;
+        private final AllImageDB handler;
 
         public ImageViewHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.a_alllist_image);
+            handler = new AllImageDB();
         }
 
         @Override
         public void setViews(Image dataclass) {
-            Picasso.get()
-                    .load(dataclass.getUrl())
-                    .into(imageView);
+            handler.getImageDownloadUrl(dataclass, this);
+        }
+
+        @Override
+        public void OnComplete(@NonNull ArrayList<Uri> docs, int queryID, int flags) {
+            if (queryID == 0) {
+                if (flags == DBOnCompleteFlags.SUCCESS.value) {
+                    Uri downloadUri = docs.get(0);
+                    int imageSideLength = imageView.getWidth() / 2;
+                    Picasso.get()
+                            .load(downloadUri)
+                            .resize(imageSideLength, imageSideLength)
+                            .centerCrop()
+                            .into(imageView);
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesDB.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
  *
  * TODO: Need redesign for better compatibility with RecyclerView pagination in AllImagesFragment for getting accounts and events.
  */
-public class AllImageDB extends DBHandler {
+public class AllImagesDB extends DBHandler {
     /**
      * Gets a long-live download uris for Picasso to get image from Firebase Storage.
      * @param image Image class with gs:// link to Firebase Storage image.

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
@@ -1,23 +1,29 @@
 package com.example.pygmyhippo.admin;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.GridLayoutManager;
 
+import com.example.pygmyhippo.common.Image;
 import com.example.pygmyhippo.common.RecyclerClickListener;
 import com.example.pygmyhippo.databinding.AdminFragmentAllListBinding;
 
+import java.util.ArrayList;
+
 public class AllImagesFragment extends Fragment implements RecyclerClickListener {
     AdminFragmentAllListBinding binding;
-
+    AllImagesAdapter adapter;
+    ArrayList<Image> imageList;
 
     @Override
     public void onItemClick(int position) {
-
+        Log.d("Admin", String.format("Image at position (%d) clicked.", position));
     }
 
     @Override
@@ -26,7 +32,12 @@ public class AllImagesFragment extends Fragment implements RecyclerClickListener
         binding =  AdminFragmentAllListBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
 
+        imageList = new ArrayList<>();
+        imageList.add(new Image("gs://pygmyhippo-b7892.appspot.com/moodengpfp.jpg", "100", Image.ImageType.Account));
+        adapter = new AllImagesAdapter(imageList, this);
 
+        binding.aAlllistRecycler.setAdapter(adapter);
+        binding.aAlllistRecycler.setLayoutManager(new GridLayoutManager(getContext(), 2));
 
         return root;
     }

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
@@ -1,3 +1,14 @@
+/**
+ * AllImagesFragment
+ *
+ * Displays all available in the system for admins to see. Displays users' profile pictures, events'
+ * posters, and facilities' pictures. Clicking on an image should navigate the admin to the relevant
+ * page with admin permissions so they may or may not delete the image.
+ *
+ * TODO: Add images for facilities
+ * TODO: Add navigation to profile, events, and (eventually) facilties.
+ */
+
 package com.example.pygmyhippo.admin;
 
 import android.graphics.Rect;
@@ -22,6 +33,9 @@ import com.example.pygmyhippo.databinding.AdminFragmentAllListBinding;
 
 import java.util.ArrayList;
 
+/**
+ * Fragment for displaying all images for admins.
+ */
 public class AllImagesFragment extends Fragment implements RecyclerClickListener, DBOnCompleteListener<Object> {
     AdminFragmentAllListBinding binding;
     AllImagesAdapter adapter;
@@ -48,7 +62,6 @@ public class AllImagesFragment extends Fragment implements RecyclerClickListener
         imageList = new ArrayList<>();
         adapter = new AllImagesAdapter(imageList, this);
 
-        // FIXME: Change how accounts and events are grabbed from DB so it works better with RecyclerView pagination.
         handler.getAccounts(1000, this);
         handler.getEvents(1000, this);
 

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
@@ -1,0 +1,39 @@
+package com.example.pygmyhippo.admin;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+import com.example.pygmyhippo.common.RecyclerClickListener;
+import com.example.pygmyhippo.databinding.AdminFragmentAllListBinding;
+
+public class AllImagesFragment extends Fragment implements RecyclerClickListener {
+    AdminFragmentAllListBinding binding;
+
+
+    @Override
+    public void onItemClick(int position) {
+
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        binding =  AdminFragmentAllListBinding.inflate(inflater, container, false);
+        View root = binding.getRoot();
+
+
+
+        return root;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
@@ -40,7 +40,7 @@ public class AllImagesFragment extends Fragment implements RecyclerClickListener
     AdminFragmentAllListBinding binding;
     AllImagesAdapter adapter;
     ArrayList<Image> imageList;
-    AllImageDB handler;
+    AllImagesDB handler;
 
     @Override
     public void onItemClick(int position) {
@@ -52,7 +52,7 @@ public class AllImagesFragment extends Fragment implements RecyclerClickListener
                              ViewGroup container, Bundle savedInstanceState) {
         binding =  AdminFragmentAllListBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
-        handler = new AllImageDB();
+        handler = new AllImagesDB();
         
         binding.aAlllistTitleText.setText(R.string.all_images_title);
         binding.aAlllistFilterByText.setVisibility(View.INVISIBLE);

--- a/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/admin/AllImagesFragment.java
@@ -1,5 +1,6 @@
 package com.example.pygmyhippo.admin;
 
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -9,7 +10,9 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.pygmyhippo.R;
 import com.example.pygmyhippo.common.Image;
 import com.example.pygmyhippo.common.RecyclerClickListener;
 import com.example.pygmyhippo.databinding.AdminFragmentAllListBinding;
@@ -31,13 +34,32 @@ public class AllImagesFragment extends Fragment implements RecyclerClickListener
                              ViewGroup container, Bundle savedInstanceState) {
         binding =  AdminFragmentAllListBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
+        
+        binding.aAlllistTitleText.setText(R.string.all_images_title);
+        binding.aAlllistFilterByText.setVisibility(View.INVISIBLE);
+        binding.aAlllistCategorySpinner.setVisibility(View.INVISIBLE);
+        binding.aAlllistOrderSpinner.setVisibility(View.INVISIBLE);
 
         imageList = new ArrayList<>();
         imageList.add(new Image("gs://pygmyhippo-b7892.appspot.com/moodengpfp.jpg", "100", Image.ImageType.Account));
+        imageList.add(new Image("gs://pygmyhippo-b7892.appspot.com/ea0wkspMQlK0Z_5tIwxomw/avatar/1000000020", "200", Image.ImageType.Account));
+        imageList.add(new Image("gs://pygmyhippo-b7892.appspot.com/ea0wkspMQlK0Z_5tIwxomw/avatar/1000000049", "300", Image.ImageType.Account));
         adapter = new AllImagesAdapter(imageList, this);
 
         binding.aAlllistRecycler.setAdapter(adapter);
         binding.aAlllistRecycler.setLayoutManager(new GridLayoutManager(getContext(), 2));
+
+        binding.aAlllistRecycler.setClipToPadding(false);
+        binding.aAlllistRecycler.setClipChildren(false);
+
+        final int itemSpacing = 20;
+        binding.aAlllistRecycler.addItemDecoration(new RecyclerView.ItemDecoration() {
+            @Override
+            public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+                super.getItemOffsets(outRect, view, parent, state);
+                outRect.set(itemSpacing, itemSpacing, itemSpacing, itemSpacing);
+            }
+        });
 
         return root;
     }

--- a/app/src/main/java/com/example/pygmyhippo/common/Image.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Image.java
@@ -1,0 +1,42 @@
+package com.example.pygmyhippo.common;
+
+public class Image {
+    private String url;
+    private String ID;
+    private ImageType type;
+
+    public enum ImageType {
+        Account,
+        Event,
+    }
+
+    public Image(String url, String ID, ImageType type) {
+        this.url = url;
+        this.ID = ID;
+        this.type = type;
+    }
+
+    public String getID() {
+        return ID;
+    }
+
+    public ImageType getType() {
+        return type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setID(String ID) {
+        this.ID = ID;
+    }
+
+    public void setType(ImageType type) {
+        this.type = type;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/app/src/main/java/com/example/pygmyhippo/database/DBHandler.java
+++ b/app/src/main/java/com/example/pygmyhippo/database/DBHandler.java
@@ -1,11 +1,14 @@
 package com.example.pygmyhippo.database;
 
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.storage.FirebaseStorage;
 
 public abstract class DBHandler {
     protected FirebaseFirestore db;
+    protected FirebaseStorage storage;
 
     public DBHandler() {
         this.db = FirebaseFirestore.getInstance();
+        this.storage = FirebaseStorage.getInstance();
     }
 }

--- a/app/src/main/res/layout/admin_all_list_image_item.xml
+++ b/app/src/main/res/layout/admin_all_list_image_item.xml
@@ -3,16 +3,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:layout_gravity="center">
 
     <ImageView
         android:id="@+id/a_alllist_image"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxWidth="128dp"
-        android:maxHeight="128dp"
-        android:minWidth="96dp"
-        android:minHeight="96dp"
+        android:layout_width="@dimen/all_image_item_side_length"
+        android:layout_height="@dimen/all_image_item_side_length"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:srcCompat="@tools:sample/avatars" />

--- a/app/src/main/res/layout/admin_all_list_image_item.xml
+++ b/app/src/main/res/layout/admin_all_list_image_item.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/a_alllist_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="128dp"
+        android:maxHeight="128dp"
+        android:minWidth="96dp"
+        android:minHeight="96dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@tools:sample/avatars" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/admin_main_activity_navigation.xml
+++ b/app/src/main/res/layout/admin_main_activity_navigation.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="24dp"
+    android:background="@color/light_purple"
+    android:textColor="@color/dark_purple">
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="match_parent"
+        android:layout_height="55dp"
+        android:background="@color/dark_purple"
+        app:itemIconTint="@drawable/nav_select"
+        app:itemRippleColor="@null"
+        app:itemTextAppearanceActive="@style/Base.Theme.PygmyHippo"
+        app:itemTextColor="@color/mid_purple"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:menu="@menu/admin_bottom_nav_menu"
+        app:itemActiveIndicatorStyle="@null"/>
+
+    <fragment
+        android:id="@+id/nav_host_fragment_activity_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toTopOf="@id/nav_view"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/admin_mobile_navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+    <!--
+    Code to change color of active icon from Jared Burrows at The Stack Overflow on November 29, 2019
+    https://stackoverflow.com/questions/51579977/how-to-change-the-icon-color-selected-on-bottom-navigation-bar-in-android-studio
+
+    app:itemIconTint="@drawable/nav_select" is the piece of code
+    -->

--- a/app/src/main/res/menu/admin_bottom_nav_menu.xml
+++ b/app/src/main/res/menu/admin_bottom_nav_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/admin_all_events"
+        android:icon="@drawable/nav_ic_calendar"
+        android:title="@null"/>
+
+    <item
+        android:id="@+id/admin_all_images"
+        android:icon="@drawable/nav_add_event"
+        android:title="@null"/>
+
+    <item
+        android:id="@+id/admin_all_profiles"
+        android:icon="@drawable/nav_ic_user"
+        android:title="@null"/>
+
+</menu>

--- a/app/src/main/res/navigation/admin_mobile_navigation.xml
+++ b/app/src/main/res/navigation/admin_mobile_navigation.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/admin_mobile_navigation"
-    app:startDestination="@+id/navigation_all_events">
+    app:startDestination="@+id/navigation_all_images">
 
     <fragment
         android:id="@+id/navigation_all_events"

--- a/app/src/main/res/navigation/admin_mobile_navigation.xml
+++ b/app/src/main/res/navigation/admin_mobile_navigation.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/admin_mobile_navigation"
+    app:startDestination="@+id/navigation_all_events">
+
+    <fragment
+        android:id="@+id/navigation_all_events"
+        android:name="com.example.pygmyhippo.admin.AllEventsFragment"
+        android:label="All Events"
+        tools:layout="@layout/admin_fragment_all_list"
+        android:background="@color/dark_purple"/>
+
+    <fragment
+        android:id="@+id/navigation_all_users"
+        android:name="com.example.pygmyhippo.admin.AllUsersFragment"
+        android:label="All Users"
+        tools:layout="@layout/admin_fragment_all_list"
+        android:background="@color/dark_purple"/>
+
+    <fragment
+        android:id="@+id/navigation_all_images"
+        android:name="com.example.pygmyhippo.admin.AllImagesFragment"
+        android:label="All Images"
+        tools:layout="@layout/admin_fragment_all_list"
+        android:background="@color/dark_purple"/>
+
+</navigation>

--- a/app/src/main/res/navigation/user_mobile_navigation.xml
+++ b/app/src/main/res/navigation/user_mobile_navigation.xml
@@ -7,20 +7,6 @@
     app:startDestination="@+id/u_my_events_menu_item">
 
     <fragment
-        android:id="@+id/navigation_all_events"
-        android:name="com.example.pygmyhippo.admin.AllEventsFragment"
-        android:label="All List"
-        tools:layout="@layout/admin_fragment_all_list"
-        android:background="@color/dark_purple"/>
-
-    <fragment
-        android:id="@+id/navigation_all_users"
-        android:name="com.example.pygmyhippo.admin.AllUsersFragment"
-        android:label="All List"
-        tools:layout="@layout/admin_fragment_all_list"
-        android:background="@color/dark_purple"/>
-
-    <fragment
         android:id="@+id/u_my_events_menu_item"
         android:name="com.example.pygmyhippo.user.MyEventsFragment"
         android:label="@string/title_myevents"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="profile_rounded">400dp</dimen>
+    <dimen name="all_image_item_side_length">180dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="title_profile">Profile</string>
     <string name="all_events_title">All Events</string>
     <string name="all_users_title">All Users</string>
+    <string name="all_images_title">All Images</string>
     <string-array name="role">
         <item>User</item>
         <item>Organiser</item>


### PR DESCRIPTION
# Code
 - Added fragment for displaying images for accounts, and events.
 - The fragment is connected to Firestore and Storage.
 - Currently does not display images related to facilities.
 - Currently does not navigate to individual pages for removing images.
 - Added Admin navigation graph.

https://github.com/user-attachments/assets/e6a3cc9f-fcb6-4f8c-a8dc-a1cfb8d10dd2

# Other
 - CRC and UML updated.
 - No intent test were made for the new fragment.
 - No unit tests were made for other classes.

