### PR TITLE
View entrants refactor

### DIFF
--- a/app/src/main/java/com/example/pygmyhippo/common/Entrant.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Entrant.java
@@ -18,11 +18,6 @@ import java.util.Collections;
 public class Entrant {
 
     private String accountID;
-    private String eventID;
-    private String name;
-    private String emailAddress;
-    private String phoneNumber;
-    private String profilePicture;
     private EntrantStatus entrantStatus;
 
     public enum EntrantStatus {
@@ -37,14 +32,6 @@ public class Entrant {
             this.value = value;
         }
     };
-
-    public Entrant(String eventID, String accountID, String name, String emailAddress, String phoneNumber) {
-        this.eventID = eventID;
-        this.accountID = accountID;
-        this.name = name;
-        this.emailAddress = emailAddress;
-        this.phoneNumber = phoneNumber;
-    }
 
     public String getAccountID() {
         return accountID;
@@ -67,45 +54,5 @@ public class Entrant {
     public Entrant(String accountID, EntrantStatus entrantStatus) {
         this.accountID = accountID;
         this.entrantStatus = entrantStatus;
-    }
-
-    public String getEventID() {
-        return eventID;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getEmailAddress() {
-        return emailAddress;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public String getProfilePicture() {
-        return profilePicture;
-    }
-
-    public void setEventID(String eventID) {
-        this.eventID = eventID;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public void setEmailAddress(String emailAddress) {
-        this.emailAddress = emailAddress;
-    }
-
-    public void setPhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
-
-    public void setProfilePicture(String profilePicture) {
-        this.profilePicture = profilePicture;
     }
 }

--- a/app/src/main/java/com/example/pygmyhippo/organizer/EntrantArrayAdapter.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/EntrantArrayAdapter.java
@@ -1,4 +1,4 @@
-package com.example.pygmyhippo;
+package com.example.pygmyhippo.organizer;
 
 /*
 The purpose of this class is to take the data from the entrants in the given filtered entrant list and display that
@@ -9,16 +9,22 @@ Outstanding Issues: Needs image functionality to be customizable, not from drawa
  */
 
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.example.pygmyhippo.R;
+import com.example.pygmyhippo.common.Account;
 import com.example.pygmyhippo.common.Entrant;
+import com.example.pygmyhippo.database.DBOnCompleteFlags;
+import com.example.pygmyhippo.database.DBOnCompleteListener;
 
 import java.util.ArrayList;
 
@@ -29,6 +35,8 @@ import java.util.ArrayList;
  *  - Make profile image change based on the user profile
  */
 public class EntrantArrayAdapter extends ArrayAdapter<Entrant> {
+    private ViewEntrantDB dbHandler;
+    private Account account;
 
     public EntrantArrayAdapter(Context context, ArrayList<Entrant> entrantListData) {
         super(context, 0, entrantListData);
@@ -56,19 +64,60 @@ public class EntrantArrayAdapter extends ArrayAdapter<Entrant> {
         }
 
         Entrant entrant = getItem(position);
+        Log.d("DB", String.format("Finding %s Account", entrant.getAccountID()));
 
         // Get all the views from the entrants_content in our xml file
         TextView accountName = view.findViewById(R.id.o_entrant_name_view);
         TextView accountPhone = view.findViewById(R.id.o_entrant_phone_view);
         TextView accountEmail = view.findViewById(R.id.o_entrant_email_view);
         TextView accountStatus = view.findViewById(R.id.o_entrant_status_txt_view);
+        TextView accountLocation = view.findViewById(R.id.o_entrant_location_txt_view);
 
-        // Replace the placeholder texts with the real values from this current Entrant account
-        accountName.setText(entrant.getName());
-        accountPhone.setText(entrant.getPhoneNumber());
-        accountEmail.setText(entrant.getEmailAddress());
+        // Set placeholders while we wait for the data to be retrieved
+        accountName.setText("Loading...");
+        accountPhone.setText("Loading...");
+        accountEmail.setText("Loading...");
+        accountLocation.setText("Loading...");
         accountStatus.setText("Status: " + entrant.getEntrantStatus().value);
 
+        // From the database, get the entrant's account info
+        dbHandler = new ViewEntrantDB();
+        dbHandler.getAccount(entrant.getAccountID(), new DBOnCompleteListener<Account>() {
+            @Override
+            public void OnComplete(@NonNull ArrayList<Account> docs, int queryID, int flags) {
+                switch (queryID) {
+                    case 1: // getAccount()
+                        if (flags == DBOnCompleteFlags.SINGLE_DOCUMENT.value) {
+                            // Get the account for this entrant
+                            account = docs.get(0);
+
+                            // Replace the placeholder texts with the real values from this current Entrant account
+                            accountName.setText(account.getName());
+                            accountPhone.setText(account.getPhoneNumber());
+                            accountEmail.setText(account.getEmailAddress());
+                            accountLocation.setText(account.getLocation());
+                            Log.d("DB", String.format("Account name:  (%s)", account.getName()));
+                            Log.d("DB", String.format("Account phone:  (%s)", account.getPhoneNumber()));
+                            Log.d("DB", String.format("Account email:  (%s)", account.getEmailAddress()));
+                        } else {
+                            // Should only ever expect 1 document, otherwise there must be an error
+                            handleDBError();
+                        }
+                        break;
+                    default:
+                        Log.i("DB", String.format("Unknown query ID (%d)", queryID));
+                        handleDBError();
+                }
+                }
+        });
         return view;
+    }
+
+    /**
+     * This method displays if there was an error in the database
+     */
+    private void handleDBError() {
+        Toast toast = Toast.makeText(getContext(), "DB Error!", Toast.LENGTH_SHORT);
+        toast.show();
     }
 }

--- a/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
@@ -54,6 +54,9 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.example.pygmyhippo.R;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+
 import java.util.Random;
 
 /**
@@ -70,9 +73,14 @@ public class EventFragment extends Fragment {
 
     // TODO: pass entrant and even information using bundle...
 
-    // populate single event page with hardcoded event information
+    // populate single event page with hardcoded event information (Note this Event is in the database, just still hardcoded)
     public Event hardcodeEvent() {
         entrants = new ArrayList<>();
+        // Add hardcoded entrants
+        entrants.add(new Entrant("5LCoIC4Ix46vPavSV1KX", Entrant.EntrantStatus.waitlisted));
+        entrants.add(new Entrant("8Bd5McHSzrYcjH99yv8Y", Entrant.EntrantStatus.invited));
+        entrants.add(new Entrant("SfSzvATHz9m9fj7vmWbp", Entrant.EntrantStatus.accepted));
+        entrants.add(new Entrant("hupsArkwU6yvvSD1tKIe", Entrant.EntrantStatus.cancelled));
 
         return event = new Event(
                 "Hippo Party",

--- a/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
@@ -8,6 +8,7 @@ Purpose is to: Allow the organiser to update their event
 Contributors: Katherine, Kori
 Issues: Doesn't have updatable fields yet
         - Isn't connected to database yet
+        - No Image handling
  */
 
 import static android.content.ContentValues.TAG;
@@ -100,12 +101,6 @@ public class EventFragment extends Fragment {
             Navigation.findNavController(view1).navigate(R.id.action_event_fragment_to_organiser_myEvents_page);
         });
 
-        // Set up the listener for viewing entrants button
-        Button viewEntrantsButton = view.findViewById(R.id.button_view_entrants);
-        viewEntrantsButton.setOnClickListener(view1 -> {
-            Navigation.findNavController(view1).navigate(R.id.action_event_fragment_to_view_entrants_fragment);
-        });
-
         TextView eventNameView = view.findViewById(R.id.u_eventNameView);
         TextView eventDateView = view.findViewById(R.id.u_eventDateView);
         TextView eventTimeView = view.findViewById(R.id.u_eventTimeView);
@@ -127,6 +122,14 @@ public class EventFragment extends Fragment {
         eventLocationView.setText(event.getLocation());
         eventCostView.setText(event.getCost());
         eventAboutDescriptionView.setText(event.getDescription());
+
+        // Set up the listener for viewing entrants button
+        Bundle eventBundle = new Bundle();
+        eventBundle.putString("eventID", event.getEventID());
+        Button viewEntrantsButton = view.findViewById(R.id.button_view_entrants);
+        viewEntrantsButton.setOnClickListener(view1 -> {
+            Navigation.findNavController(view1).navigate(R.id.action_event_fragment_to_view_entrants_fragment, eventBundle);
+        });
 
         // If the event is closed, then change the style of the draw button
         if (event.getEventStatus().value.equals("cancelled")) {

--- a/app/src/main/java/com/example/pygmyhippo/organizer/ViewEntrantDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/ViewEntrantDB.java
@@ -1,0 +1,91 @@
+package com.example.pygmyhippo.organizer;
+
+/*
+This class handles the database queries necessary for the View Entrants fragment.
+Contributors: Kori, James (for code style)
+
+Purposes:
+    - Get the event to display the entrant list
+    - Get the Account of said entrant to display their names in the array adapter
+Issues:
+    - None so far
+ */
+
+import android.util.Log;
+
+import com.example.pygmyhippo.common.Account;
+import com.example.pygmyhippo.common.Event;
+import com.example.pygmyhippo.database.DBHandler;
+import com.example.pygmyhippo.database.DBOnCompleteFlags;
+import com.example.pygmyhippo.database.DBOnCompleteListener;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+
+/**
+ * DB Handler for ViewEntrantsFragment
+ */
+public class ViewEntrantDB extends DBHandler {
+
+    /**
+     * This method returns the matching event
+     * @param eventID
+     * @param listener
+     */
+    public void getEvent(String eventID, DBOnCompleteListener<Event> listener) {
+        db.collection("Events")
+                .whereEqualTo("eventID", eventID)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        QuerySnapshot queryResult = task.getResult();
+                        ArrayList<Event> events = new ArrayList<>();
+                        queryResult.forEach(doc -> events.add(doc.toObject(Event.class)));
+                        if (events.size() == 0) {
+                            Log.d("DB", String.format("Found no events with event ID (%s)", eventID));
+                            listener.OnComplete(events, 0, DBOnCompleteFlags.NO_DOCUMENTS.value);
+                        } else if (events.size() == 1) {
+                            Log.d("DB", String.format("Found event (%s) with event ID (%s)", events.get(0).getEventID(), eventID));
+                            listener.OnComplete(events, 0, DBOnCompleteFlags.SINGLE_DOCUMENT.value);
+                        } else {
+                            Log.d("DB", String.format("Found %d events  with event ID (%s)", events.size(), eventID));
+                            listener.OnComplete(events, 0, DBOnCompleteFlags.MULTIPLE_DOCUMENTS.value);
+                        }
+                    } else {
+                        Log.d("DB", String.format("Could not get event with event ID (%s).", eventID));
+                        listener.OnComplete(new ArrayList<>(), 0, DBOnCompleteFlags.ERROR.value);
+                    }
+                });
+    }
+
+    /**
+     * This method returns the account matching the entrant from the list
+     * @param accountID
+     * @param listener
+     */
+    public void getAccount(String accountID, DBOnCompleteListener<Account> listener) {
+        db.collection("Accounts")
+                .whereEqualTo("accountID", accountID)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        QuerySnapshot queryResult = task.getResult();
+                        ArrayList<Account> accounts = new ArrayList<>();
+                        queryResult.forEach(doc -> accounts.add(doc.toObject(Account.class)));
+                        if (accounts.size() == 0) {
+                            Log.d("DB", String.format("Found no accounts with account ID (%s)", accountID));
+                            listener.OnComplete(accounts, 1, DBOnCompleteFlags.NO_DOCUMENTS.value);
+                        } else if (accounts.size() == 1) {
+                            Log.d("DB", String.format("Found account (%s) with account ID (%s)", accounts.get(0).getAccountID(), accountID));
+                            listener.OnComplete(accounts, 1, DBOnCompleteFlags.SINGLE_DOCUMENT.value);
+                        } else {
+                            Log.d("DB", String.format("Found %d accounts  with account ID (%s)", accounts.size(), accountID));
+                            listener.OnComplete(accounts, 1, DBOnCompleteFlags.MULTIPLE_DOCUMENTS.value);
+                        }
+                    } else {
+                        Log.d("DB", String.format("Could not get account with account ID (%s).", accountID));
+                        listener.OnComplete(new ArrayList<>(), 1, DBOnCompleteFlags.ERROR.value);
+                    }
+                });
+    }
+}

--- a/app/src/main/res/navigation/organiser_mobile_navigation.xml
+++ b/app/src/main/res/navigation/organiser_mobile_navigation.xml
@@ -55,6 +55,9 @@ app:startDestination="@+id/organiser_postEvent_page">
         <action
             android:id="@+id/action_view_entrants_fragment_to_event_fragment"
             app:destination="@id/event_fragment" />
+        <argument
+            android:name="eventID"
+            app:argType="string" />
     </fragment>
 
     <fragment

--- a/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
@@ -1,0 +1,217 @@
+package com.example.pygmyhippo.Organiser;
+
+/*
+This Class is used to test the list filtering methods used in ViewEntrantsFragment
+Author: Kori
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import com.example.pygmyhippo.common.Entrant;
+import com.example.pygmyhippo.common.Event;
+import com.example.pygmyhippo.organizer.ViewEntrantsFragment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class ViewEntrantsFragmentTest {
+    private Event testEvent;
+    private ViewEntrantsFragment viewEntrantsFragment;
+
+    @Before
+    public void setUp() {
+        // Make an instance of the fragment
+        viewEntrantsFragment = new ViewEntrantsFragment();
+
+        // Make an example Event object
+        testEvent = new Event(
+                "Hippo Party",
+                "event1",
+                "The Hippopotamus Society",
+                new ArrayList<>(),
+                "The Swamp",
+                "2024-10-31",
+                // TODO: there is a bit of an issue with aligning the time when it is shorter on the xml
+                "4:00 PM MST - 4:00 AM MST",
+                "Love hippos and a party? Love a party! Join a party! We have lots of really cool hippos I'm sure you'd love to meet! There will be food, games, and all sorts of activities you could imagine! It's almost worth the price to see Moo Deng and his buddies!",
+                "$150.00",
+                "hippoparty.png",
+                Event.EventStatus.ongoing,
+                true);
+        testEvent.setEventWinnersCount(20);
+
+    }
+
+    @Test
+    public void onlyWaitlistTest() {
+        // Fill the event with just waitlisted for now
+        for (int id = 0 ; id < 150 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.waitlisted);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants are the waitlisted ones
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        assertEquals(150, filterList.size());
+        // Check that they are all actually waitlisted
+        for (int id = 0 ; id < 150 ; id++) {
+            assertEquals("waitlisted", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+    }
+
+    @Test
+    public void onlyInvitedTest() {
+        // Fill the event with just waitlisted for now
+        for (int id = 0 ; id < 100 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.invited);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants are the waitlisted ones
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(100, filterList.size());
+        // Check that they are all actually Invited
+        for (int id = 0 ; id < 100 ; id++) {
+            assertEquals("invited", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+    }
+
+    @Test
+    public void onlyCancelledTest() {
+        // Fill the event with just waitlisted for now
+        for (int id = 0 ; id < 200 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.cancelled);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants are the waitlisted ones
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(200, filterList.size());
+        // Check that they are all actually Cancelled
+        for (int id = 0 ; id < 200 ; id++) {
+            assertEquals("cancelled", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+    }
+
+    @Test
+    public void onlyAcceptedTest() {
+        // Fill the event with just waitlisted for now
+        for (int id = 0 ; id < 180 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.accepted);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants are the waitlisted ones
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(180, filterList.size());
+        // Check that they are all actually accepted
+        for (int id = 0 ; id < 100 ; id++) {
+            assertEquals("accepted", filterList.get(id).getEntrantStatus().value);
+        }
+    }
+
+    @Test
+    public void MixedStatusesTest() {
+        // Fill the event with just waitlisted for now
+        int id = 0;
+        for (id = 0 ; id < 5 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.waitlisted);
+            testEvent.addEntrant(newEntrant);
+        }
+        for ( ; id < 11 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.invited);
+            testEvent.addEntrant(newEntrant);
+        }
+        for ( ; id < 18 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.cancelled);
+            testEvent.addEntrant(newEntrant);
+        }
+        for ( ; id < 26 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.accepted);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants are the waitlisted ones
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        assertEquals(5, filterList.size());
+
+        // Check that they are all actually waitlisted
+        for (id = 0 ; id < 5 ; id++) {
+            assertEquals("waitlisted", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(6, filterList.size());
+
+        // Check that they are all actually Invited
+        for (id = 0 ; id < 6 ; id++) {
+            assertEquals("invited", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(7, filterList.size());
+
+        // Check that they are all actually cancelled
+        for (id = 0 ; id < 7 ; id++) {
+            assertEquals("cancelled", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(8, filterList.size());
+        // Check that they are all actually accepted
+        for (id = 0 ; id < 8 ; id++) {
+            assertEquals("accepted", filterList.get(id).getEntrantStatus().value);
+        }
+    }
+}

--- a/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
@@ -1,8 +1,8 @@
 package com.example.pygmyhippo.Organiser;
 
-/*
-This Class is used to test the list filtering methods used in ViewEntrantsFragment
-Author: Kori
+/**
+*This Class is used to test the list filtering methods used in ViewEntrantsFragment
+*Author: Kori
  */
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
I fixed the ViewEntrantsFragment to correlate with how we are implementing the Entrant class. There's a sample event class in the database with the "hardcoded" data that this sample goes off of. Navigating to the entrant list does pass the eventID to the fragment and that's how it gets its data now, but still haven't gotten db connection to the EventFragment in the organiser folder.

https://github.com/user-attachments/assets/80a21cce-2d94-4dcf-8187-12090a9a0870

### Other: 

- CRC Updated
- UML updated
- Storyboard still up to date
- added unit tests for list filtering
- Still haven't updated UI testing