### PR TITLE
Add default nav-args for adminViewAccountID on profile

### DIFF
--- a/app/src/main/res/navigation/admin_mobile_navigation.xml
+++ b/app/src/main/res/navigation/admin_mobile_navigation.xml
@@ -90,7 +90,8 @@
         <argument
             android:name="adminViewAccountID"
             app:argType="string"
-            app:nullable="true" />
+            app:nullable="true"
+            android:defaultValue="null" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/navigation/user_mobile_navigation.xml
+++ b/app/src/main/res/navigation/user_mobile_navigation.xml
@@ -43,7 +43,8 @@
         <argument
             android:name="adminViewAccountID"
             app:argType="string"
-            app:nullable="true" />
+            app:nullable="true"
+            android:defaultValue="null" />
     </fragment>
     <fragment
         android:id="@+id/eventFragment"


### PR DESCRIPTION
Fixed bug mentioned in discord bug report channel regarding navigation to profile as user.

No other additions made.