### PR TITLE
US 01.02.01 new user signup and navigation

### DIFF
--- a/app/src/androidTest/java/com/example/pygmyhippo/organiser/ProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/example/pygmyhippo/organiser/ProfileFragmentTest.java
@@ -3,13 +3,15 @@ package com.example.pygmyhippo.organiser;
 /*
 UI tests for the organiser profile fragment
 Issues:
-    - Needs spinner testing when navigation gets updated
+    - Test spinner in other profile fragment with more than one role
  */
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -21,6 +23,7 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.assertion.ViewAssertions;
+import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -54,6 +57,7 @@ public class ProfileFragmentTest {
         Account account = new Account();
         account.setAccountID("0");
         account.setName("Testing account");
+        account.getRoles().add(Account.AccountRole.user);
         account.setCurrentRole(Account.AccountRole.user);
         intent.putExtra("signedInAccount", account);
 
@@ -181,5 +185,11 @@ public class ProfileFragmentTest {
         onView(withId(R.id.O_profile_facilityImg)).check(ViewAssertions.matches(isDisplayed()));
         onView(withText("University of Alberta")).check(ViewAssertions.matches(isDisplayed()));
         onView(withText("Whyte Ave")).check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void testUserSpinner() {
+        // The beginning account only has one role, so the spinner should not show up
+        onView(withId(R.id.o_roleSpinner)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)));
     }
 }

--- a/app/src/androidTest/java/com/example/pygmyhippo/user/NewUserTest.java
+++ b/app/src/androidTest/java/com/example/pygmyhippo/user/NewUserTest.java
@@ -1,0 +1,285 @@
+package com.example.pygmyhippo.user;
+
+/*
+UI Testing for the create user alert dialog
+These tests check that the alert dialog only closes when the required fields are set
+Issues:
+    - Consider testing navigation to the right role
+ */
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Bundle;
+import android.provider.Settings;
+
+
+import androidx.annotation.NonNull;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.espresso.assertion.ViewAssertions;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.GrantPermissionRule;
+
+import com.example.pygmyhippo.MainActivity;
+import com.example.pygmyhippo.R;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@LargeTest
+public class NewUserTest {
+    @Rule
+    public ActivityScenarioRule<MainActivity> scenario = new ActivityScenarioRule<>(createIntent());
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS);
+
+    public static Intent createIntent() {
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_MAIN);
+        intent.setClassName("com.example.pygmyhippo", "com.example.pygmyhippo.MainActivity");
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+
+        return intent;
+    }
+
+    @Before
+    public void setup() {
+        scenario.getScenario().onActivity(activity -> {
+            Bundle navArgs = new Bundle();
+            navArgs.putBoolean("useFirebase", true);
+            navArgs.putBoolean("useNavigation", false);
+        });
+    }
+
+    @Test
+    public void testDisplay() {
+        onView(withId(R.id.new_name_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_email_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_phone_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withText("Select Permanent Role(s):"))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_user))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_organiser))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void testNoFields() {
+        onView(withText("Create"))
+                .inRoot(isDialog())
+                .perform(click());
+
+        // Check that it didn't go through by seeing that the dialog box is still visible
+        onView(withId(R.id.new_name_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_email_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_phone_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withText("Select Permanent Role(s):"))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_user))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_organiser))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void testNameFields() {
+        // Add name but no email, shouldn't go through
+        // Update name
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.typeText("Bobby Hill"));
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("Bobby Hill")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        onView(withText("Create"))
+                .inRoot(isDialog())
+                .perform(click());
+
+        // Check that it didn't go through by seeing that the dialog box is still visible
+        onView(withId(R.id.new_name_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_email_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_phone_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withText("Select Permanent Role(s):"))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_user))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_organiser))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void testEmailFields() {
+        // Add email but no name, shouldn't go through
+        // Update email
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.typeText("bobby@yahoo.ca"));
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("bobby@yahoo.ca")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        onView(withText("Create"))
+                .inRoot(isDialog())
+                .perform(click());
+
+        // Check that it didn't go through by seeing that the dialog box is still visible
+        onView(withId(R.id.new_name_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_email_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_phone_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withText("Select Permanent Role(s):"))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_user))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_organiser))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void testNoRoles() {
+        // Add email and name and phone, but no roles: It shouldn't go through
+        // Update name
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.typeText("Bobby Hill"));
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("Bobby Hill")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        // Update email
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.typeText("bobby@yahoo.ca"));
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("bobby@yahoo.ca")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        // Update phone
+        onView(withId(R.id.new_phone_txt)).inRoot(isDialog()).perform(ViewActions.typeText("780 111 2222"));
+        onView(withId(R.id.new_phone_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("780 111 2222")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+
+        onView(withText("Create"))
+                .inRoot(isDialog())
+                .perform(click());
+
+        // Check that it didn't go through by seeing that the dialog box is still visible
+        onView(withId(R.id.new_name_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_email_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_phone_txt))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withText("Select Permanent Role(s):"))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_user))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+        onView(withId(R.id.new_role_organiser))
+                .inRoot(isDialog())
+                .check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @Test
+    public void ZTestCompleteCreation() throws InterruptedException {
+        // Add email and name and phone, and a role, it should go through
+        // Update name
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.typeText("This is hopefully a very specific test name"));
+        onView(withId(R.id.new_name_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("This is hopefully a very specific test name")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        // Update email
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.typeText("bobby@yahoo.ca"));
+        onView(withId(R.id.new_email_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("bobby@yahoo.ca")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        // Update phone
+        onView(withId(R.id.new_phone_txt)).inRoot(isDialog()).perform(ViewActions.typeText("780 111 2222"));
+        onView(withId(R.id.new_phone_txt)).inRoot(isDialog()).perform(ViewActions.closeSoftKeyboard());
+        onView(withText("780 111 2222")).inRoot(isDialog()).check(ViewAssertions.matches(isDisplayed()));
+
+        // Pick organiser role
+        // Update phone
+        onView(withId(R.id.new_role_organiser)).inRoot(isDialog()).perform(click());
+        onView(withId(R.id.new_role_organiser)).inRoot(isDialog()).check(ViewAssertions.matches(isChecked()));
+
+        onView(withText("Create"))
+                .inRoot(isDialog())
+                .perform(click());
+
+        // Check that it did go through and text from the post event fragment is visible
+        // Meaning it navigated to the right role
+        Thread.sleep(5500);     // Wait for the layout to change
+        onView(withText("Event Details")).check(ViewAssertions.matches(isDisplayed()));
+    }
+
+    @After
+    public void cleanUp() {
+        // Remove the account that got added by the class
+        scenario.getScenario().onActivity(activity -> {
+            FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+            // Get rid of the account with the test name
+            db.collection("Accounts")
+                    .whereEqualTo("name", "This is hopefully a very specific test name")
+                    .get()
+                    .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                        @Override
+                        public void onComplete(@NonNull Task<QuerySnapshot> task) {
+
+                        }
+                    });
+        });
+    }
+}

--- a/app/src/androidTest/java/com/example/pygmyhippo/user/NewUserTest.java
+++ b/app/src/androidTest/java/com/example/pygmyhippo/user/NewUserTest.java
@@ -6,6 +6,7 @@ These tests check that the alert dialog only closes when the required fields are
 Issues:
     - Testing can only be done with an emulator whose device ID is not in the database
     - Test data is deleted by name, so could potentially delete an account with the same name
+            Tried to handle this by only deleting if one account with such name exists
  */
 
 import static androidx.test.espresso.Espresso.onView;

--- a/app/src/main/java/com/example/pygmyhippo/MainActivity.java
+++ b/app/src/main/java/com/example/pygmyhippo/MainActivity.java
@@ -10,11 +10,15 @@ Issues:
  */
 
 import android.Manifest;
+import android.app.AlertDialog;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.Log;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -219,6 +223,13 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
                     toast.show();
                     setupNavController();
                 } else if (flags == DBOnCompleteFlags.NO_DOCUMENTS.value) {
+                    // First make a dialog builder that the user must to fill out important initial details
+                    AlertDialog.Builder builder = formatBuilder();
+
+                    // Show the builder
+                    AlertDialog createAccount = builder.create();
+                    createAccount.show();
+
                     dbHandler.addNewDevice(getDeviceID(), this);
                 } else {
                     handleDBError();
@@ -244,6 +255,31 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
                 Log.i("DB", String.format("Unknown query ID (%d)", queryID));
                 handleDBError();
         }
+    }
+
+    /**
+     * This method will format the builder used for the user to enter in their profile details
+     * @author Kori
+     * @return The builder once its formatted
+     */
+    public AlertDialog.Builder formatBuilder() {
+        // Set the title and message
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("Create Account");
+        builder.setMessage("Fill in the required details to continue:");
+        builder.setCancelable(false);
+
+        // Get the layout and set that to the builder
+        // This code snippet is from https://stackoverflow.com/questions/10226740/get-linearlayout-from-another-xml-android
+        // Accessed on 2024-11-24
+        LayoutInflater inflater;
+        inflater = (LayoutInflater) this.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LinearLayout builderLayout = (LinearLayout) inflater.inflate(R.layout.create_user_dialog_content , null);
+
+        // Set the retrieved layout view
+        builder.setView(builderLayout);
+
+        return builder;
     }
 
     /**

--- a/app/src/main/java/com/example/pygmyhippo/MainActivity.java
+++ b/app/src/main/java/com/example/pygmyhippo/MainActivity.java
@@ -431,7 +431,6 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
         Log.d("MainActivity", String.format("Received %s as current role.", receivedRole));
         if (receivedRole == null) {
             // If the account didn't exist, they get automatically set as a user for now
-            currentRole = Account.AccountRole.user;
         } else {
             // Actually set the role of the incoming account
             switch (receivedRole) {

--- a/app/src/main/java/com/example/pygmyhippo/MainActivity.java
+++ b/app/src/main/java/com/example/pygmyhippo/MainActivity.java
@@ -6,7 +6,7 @@ Purposes:
     - Sets up the navbar for navigating between the three fragments (for any role)
     - Signs an account in based on device ID
 Issues:
-    - Double account creation when a new device tries to open the app.
+    - Decide where to put notification permission handler
  */
 
 
@@ -49,7 +49,6 @@ import java.util.Arrays;
 /**
  * Main Activity for our android app
  *
- * FIXME: Double account creation when a new device tries to open the app.
  * @author Jennifer, Griffin
  */
 public class MainActivity extends AppCompatActivity implements DBOnCompleteListener<Account> {
@@ -231,6 +230,9 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
                             String.format("Got account (%s)", signedInAccount.getAccountID()),
                             Toast.LENGTH_SHORT);
                     toast.show();
+
+                    // Set up the current role navigation
+                    currentRole = signedInAccount.getCurrentRole();
                     setupNavController();
                 } else if (flags == DBOnCompleteFlags.NO_DOCUMENTS.value) {
                     // Make the new signed in account with the recorded device ID
@@ -309,6 +311,9 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
                             Toast.LENGTH_SHORT);
                     toast.show();
                     signedInAccount = docs.get(0);
+
+                    // Set up the current role navigation
+                    currentRole = signedInAccount.getCurrentRole();
                     setupNavController();
                 } else {
                     Toast toast = Toast.makeText(this,
@@ -426,7 +431,6 @@ public class MainActivity extends AppCompatActivity implements DBOnCompleteListe
         Log.d("MainActivity", String.format("Received %s as current role.", receivedRole));
         if (receivedRole == null) {
             // If the account didn't exist, they get automatically set as a user for now
-            // TODO: Allow user to decide the role they want
             currentRole = Account.AccountRole.user;
         } else {
             // Actually set the role of the incoming account

--- a/app/src/main/java/com/example/pygmyhippo/common/Account.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Account.java
@@ -66,7 +66,6 @@ public class Account implements Parcelable {
         this.enableGeolocation = false;
 
         this.roles = new ArrayList<>();
-        this.roles.add(AccountRole.user);
 
         this.facilityProfile = new Facility();
     }

--- a/app/src/main/java/com/example/pygmyhippo/common/Facility.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Facility.java
@@ -23,7 +23,11 @@ public class Facility implements Parcelable {
     private String name;
     private String location;
 
-    public Facility() {}
+    public Facility() {
+        this.facilityPicture = "";
+        this.name = "";
+        this.location = "";
+    }
     public Facility(String facilityPicture, String name, String location) {
         this.facilityPicture = facilityPicture;
         this.name = name;
@@ -113,9 +117,9 @@ public class Facility implements Parcelable {
      * @return true it it exists, false if all attributes are null
      */
     public boolean facilityExists() {
-        if (name == null) {
-            if (location == null) {
-                if (facilityPicture == null) {
+        if (name.isEmpty()) {
+            if (location.isEmpty()) {
+                if (facilityPicture.isEmpty()) {
                     return false;
                 }
             }

--- a/app/src/main/java/com/example/pygmyhippo/database/MainActivityDB.java
+++ b/app/src/main/java/com/example/pygmyhippo/database/MainActivityDB.java
@@ -60,19 +60,16 @@ public class MainActivityDB extends DBHandler {
     }
 
     /**
-     * Creates a new account and adds it to Accounts collection.
+     * Takes a new account and adds it to Accounts collection.
      *
      * Query ID: 1.
-     * @param deviceID - device ID to use for the new account.
+     * @param newAccount - new account with preset deviceID
      * @param listener - onCompleteListener to call after query completes.
      */
-    public void addNewDevice(String deviceID, DBOnCompleteListener<Account> listener) {
-        Log.d("DB", String.format("Adding new account with device ID (%s)", deviceID));
+    public void addNewDevice(Account newAccount, DBOnCompleteListener<Account> listener) {
+        Log.d("DB", String.format("Adding new account with device ID (%s)", newAccount.getDeviceID()));
         DocumentReference docRef = db.collection("Accounts").document();
-        Account newAccount = new Account();
         newAccount.setAccountID(docRef.getId());
-        newAccount.setDeviceID(deviceID);
-        newAccount.setCurrentRole(Account.AccountRole.user);
         docRef.set(newAccount).addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
                 ArrayList<Account> accounts = new ArrayList<>();

--- a/app/src/main/java/com/example/pygmyhippo/organizer/ProfileFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/ProfileFragment.java
@@ -105,8 +105,7 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
                         binding.OProfileFacilityImg.setImageURI(uri);
 
                         // If the user already had a profile picture, make sure to delete the old one first
-                        if (signedInAccount.getFacilityProfile().getFacilityPicture() != null
-                                && !signedInAccount.getFacilityProfile().getFacilityPicture().isEmpty()) {
+                        if (!signedInAccount.getFacilityProfile().getFacilityPicture().isEmpty()) {
                             imageHandler.DeleteImageByURL(signedInAccount.getFacilityProfile().getFacilityPicture(), this);
                         }
 
@@ -288,9 +287,6 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
                 uploadIm_btn.setVisibility(View.GONE);
                 deleteIm_btn.setVisibility(View.GONE);
                 facility_uploadIm_btn.setVisibility(View.GONE);
-                if (!signedInAccount.getFacilityProfile().facilityExists()) {
-                    createFacilityButton.setVisibility(View.VISIBLE);
-                }
 
                 // Update the corresponding fields of the account
                 signedInAccount.setName(name_f.getText().toString());
@@ -302,6 +298,14 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
                 String facilityLocation = facilityLocation_f.getText().toString();
                 signedInAccount.getFacilityProfile().setName(facilityName);
                 signedInAccount.getFacilityProfile().setLocation(facilityLocation);
+
+                if (facilityName.isEmpty()
+                        && facilityLocation.isEmpty()
+                        && signedInAccount.getFacilityProfile().getFacilityPicture().isEmpty()) {
+                    createFacilityButton.setVisibility(View.VISIBLE);
+                } else {
+                    createFacilityButton.setVisibility(View.GONE);
+                }
 
                 // Update to reflect in the database
                 handler.updateProfile(signedInAccount, new DBOnCompleteListener<Account>() {
@@ -468,7 +472,7 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
         }
 
         // Get the facility picture if it has already been set
-        if (signedInAccount.getFacilityProfile().getFacilityPicture() != null) {
+        if (!signedInAccount.getFacilityProfile().getFacilityPicture().isEmpty()) {
             // Get the profile picture
             imageHandler.getImageDownloadUrl(signedInAccount.getFacilityProfile().getFacilityPicture(), new StorageOnCompleteListener<Uri>() {
                 @Override

--- a/app/src/main/java/com/example/pygmyhippo/organizer/ProfileFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/ProfileFragment.java
@@ -51,6 +51,7 @@ import com.squareup.picasso.Picasso;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 
 
@@ -157,22 +158,6 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
         binding = OrganiserFragmentProfileBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
 
-        // Initialize the role spinner
-        Spinner role_dropdown = binding.oRoleSpinner;
-        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
-                root.getContext(),
-                R.array.role,
-                R.layout.e_p_role_dropdown
-        );
-
-        adapter.setDropDownViewResource(R.layout.e_p_role_dropdown);
-        role_dropdown.setSelection(adapter.getPosition("organiser"));
-
-        role_dropdown.setAdapter(adapter);
-
-        // need to do this so the listener is connected
-        role_dropdown.setOnItemSelectedListener(this);
-
         // Get buttons
         ImageView editButton = root.findViewById(R.id.O_profile_editBtn);
         Button updateButton = root.findViewById(R.id.O_profile_updateBtn);
@@ -203,6 +188,39 @@ public class ProfileFragment extends Fragment implements AdapterView.OnItemSelec
         handler = new AccountDB();
         imageHandler = new ImageStorage();
         setProfile();
+
+        Spinner roleSpinner = binding.oRoleSpinner;
+
+        // Set up the spinner for assigned roles (only if the account has more than one role)
+        if (signedInAccount.getRoles().size() > 1) {
+            // Make the string array depending on the roles of the account
+            ArrayList<String> rolesList = new ArrayList<String>();
+            rolesList.add("-- select role --");         // For display
+
+            // Add each role to the array
+            for (int index = 0; index < signedInAccount.getRoles().size(); index++) {
+                rolesList.add(signedInAccount.getRoles().get(index).value);
+            }
+
+            // Convert the ArrayList to a String[]
+            // From https://www.geeksforgeeks.org/convert-an-arraylist-of-string-to-a-string-array-in-java/
+            // Accessed on 2024-11-24
+            String[] roles = Arrays.copyOf(rolesList.toArray(),
+                    rolesList.size(), String[].class);
+
+            // https://stackoverflow.com/questions/2505207/how-to-add-item-to-spinners-arrayadapter
+            // Helped understand this. Accessed on 2024-11-24
+            ArrayAdapter<CharSequence> roleAdapter = new ArrayAdapter<>(getContext(),
+                    R.layout.e_p_role_dropdown,
+                    roles);
+
+            roleSpinner.setAdapter(roleAdapter);
+
+            roleSpinner.setOnItemSelectedListener(this);
+        } else {
+            // Make the spinner gone since the user can't change roles
+            roleSpinner.setVisibility(View.GONE);
+        }
 
 
         // Allows te page elements to be edited by the user if the edit button is clicked

--- a/app/src/main/java/com/example/pygmyhippo/user/ProfileFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/user/ProfileFragment.java
@@ -14,6 +14,7 @@ Issues:
  */
 
 import android.Manifest;
+import android.content.res.Resources;
 import android.widget.AdapterView;
 import android.widget.CheckBox;
 
@@ -54,6 +55,7 @@ import com.squareup.picasso.Picasso;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 
 import de.hdodenhof.circleimageview.CircleImageView;
@@ -218,16 +220,38 @@ public class ProfileFragment extends Fragment  implements AdapterView.OnItemSele
 
         roleSpinner = binding.uRoleSpinner;
 
-        ArrayAdapter<CharSequence> roleAdapter = ArrayAdapter.createFromResource(
-                root.getContext(),
-                R.array.role,
-                R.layout.e_p_role_dropdown
-        );
-        roleSpinner.setAdapter(roleAdapter);
-
-        roleSpinner.setOnItemSelectedListener(this);
-
         setProfile();
+
+        // Set up the spinner for assigned roles (only if the account has more than one role)
+        if (signedInAccount.getRoles().size() > 1) {
+            // Make the string array depending on the roles of the account
+            ArrayList<String> rolesList = new ArrayList<String>();
+            rolesList.add("-- select role --");         // For display
+
+            // Add each role to the array
+            for (int index = 0; index < signedInAccount.getRoles().size(); index++) {
+                rolesList.add(signedInAccount.getRoles().get(index).value);
+            }
+
+            // Convert the ArrayList to a String[]
+            // From https://www.geeksforgeeks.org/convert-an-arraylist-of-string-to-a-string-array-in-java/
+            // Accessed on 2024-11-24
+            String[] roles = Arrays.copyOf(rolesList.toArray(),
+                    rolesList.size(), String[].class);
+
+            // https://stackoverflow.com/questions/2505207/how-to-add-item-to-spinners-arrayadapter
+            // Helped understand this. Accessed on 2024-11-24
+            ArrayAdapter<CharSequence> roleAdapter = new ArrayAdapter<>(getContext(),
+                    R.layout.e_p_role_dropdown,
+                    roles);
+
+            roleSpinner.setAdapter(roleAdapter);
+
+            roleSpinner.setOnItemSelectedListener(this);
+        } else {
+            // Make the spinner gone since the user can't change roles
+            roleSpinner.setVisibility(View.GONE);
+        }
 
 
         /*

--- a/app/src/main/res/layout/create_user_dialog_content.xml
+++ b/app/src/main/res/layout/create_user_dialog_content.xml
@@ -34,7 +34,7 @@
         android:ems="13"
         android:layout_gravity="center"
         android:fontFamily="@font/roboto_mono_medium"
-        android:hint="Phone Number"
+        android:hint="Phone Number (optional)"
         android:inputType="phone"
         android:textColor="@color/dark_purple"/>
     <TextView

--- a/app/src/main/res/layout/create_user_dialog_content.xml
+++ b/app/src/main/res/layout/create_user_dialog_content.xml
@@ -56,7 +56,7 @@
         android:layout_gravity="center"
         android:checked="false"
         android:fontFamily="@font/roboto_mono_medium"
-        android:text="User"
+        android:text="Entrant"
         android:textColor="@color/dark_purple"/>
     <CheckBox
         android:id="@+id/new_role_organiser"

--- a/app/src/main/res/layout/create_user_dialog_content.xml
+++ b/app/src/main/res/layout/create_user_dialog_content.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/create_user_layout"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/new_name_txt"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:layout_gravity="center"
+        android:ems="13"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:hint="Name"
+        android:inputType="text"
+        android:textColor="@color/dark_purple"/>
+
+    <EditText
+        android:id="@+id/new_email_txt"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:layout_gravity="center"
+        android:ems="13"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:hint="Email"
+        android:inputType="text"
+        android:textColor="@color/dark_purple"/>
+
+    <EditText
+        android:id="@+id/new_phone_txt"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:ems="13"
+        android:layout_gravity="center"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:hint="Phone Number"
+        android:inputType="phone"
+        android:textColor="@color/dark_purple"/>
+    <TextView
+        android:id="@+id/new_roles_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="20dp"
+        android:layout_gravity="center"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:text="Select Permanent Role(s):"
+        android:textColor="@color/dark_purple"
+        android:textSize="18sp"/>
+
+    <CheckBox
+        android:id="@+id/new_role_user"
+        android:layout_width="305dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center"
+        android:checked="false"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:text="User"
+        android:textColor="@color/dark_purple"/>
+    <CheckBox
+        android:id="@+id/new_role_organiser"
+        android:layout_width="305dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center"
+        android:checked="false"
+        android:fontFamily="@font/roboto_mono_medium"
+        android:text="Organiser"
+        android:textColor="@color/dark_purple"/>
+
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,12 +8,6 @@
     <string name="all_events_title">All Events</string>
     <string name="all_users_title">All Users</string>
     <string name="all_images_title">All Images</string>
-    <string-array name="role">
-        <item>-- select role --</item>
-        <item>User</item>
-        <item>Organiser</item>
-        <item>Admin</item>
-    </string-array>
     <string name="filler_long">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/app/src/test/java/com/example/pygmyhippo/Common/FacilityTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Common/FacilityTest.java
@@ -67,11 +67,11 @@ public class FacilityTest {
         newFacility.setName("Some Facility");
         assertTrue(newFacility.facilityExists());
 
-        newFacility.setName(null);
+        newFacility.setName("");
         newFacility.setLocation("88 St. 45 Ave");
         assertTrue(newFacility.facilityExists());
 
-        newFacility.setLocation(null);
+        newFacility.setLocation("");
         newFacility.setFacilityPicture("https//:image/url");
         assertTrue(newFacility.facilityExists());
 


### PR DESCRIPTION
### Details:

- Whenever a new account is being made, the dialog box will pop up and take in that info to store in the database
- The dialog will only close if name and email and role has been filled out
- This PR also fixes our navigation to match the final expectation: Users pick their roles when they first sign up and that's the only navigation options they get. If they have both they can navigate between user and organiser but if they only have one role, the spinner won't show. To see admin stuff you'll have to actually hardcode it into the account list of roles

### Demo:

https://github.com/user-attachments/assets/36d7c2f5-e3e0-443d-9754-51236c8a7ca2

### Checklist:

- [x] UML
- [x] Story board
- [x] Unit testing (no new testing here)
- [x] UI testing (PASSES AND SORTA TESTS DB 🎉🎉🎉)