### PR TITLE
Refactor Entrant Statuses

### DIFF
--- a/app/src/main/java/com/example/pygmyhippo/common/Entrant.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Entrant.java
@@ -31,11 +31,12 @@ public class Entrant {
     private Double latitude;
 
     public enum EntrantStatus {
-        waitlisted("waitlisted"),
-        cancelled("cancelled"),
-        invited("invited"),
-        accepted("accepted"),
-        rejected("rejected");
+        waitlisted("waitlisted"),       // Initial starting in waitlist
+        cancelled("cancelled"),         // Was invited but organiser cancels them
+        invited("invited"),             // "won" the lottery, acceptance is pending
+        accepted("accepted"),           // Won and accepted invite, they are in the final enrolled list
+        rejected("rejected"),           // Won but rejected invite
+        lost("lost");                   // The losers of the draw, waiting for a redraw
 
         public final String value;
 

--- a/app/src/main/java/com/example/pygmyhippo/common/Event.java
+++ b/app/src/main/java/com/example/pygmyhippo/common/Event.java
@@ -333,7 +333,6 @@ public class Event {
      * @return the poster link
      */
     public String getEventPoster() {
-        // FIXME: how are we going to handle images since this would have to return a link to image on firestore
         return eventPoster;
     }
 
@@ -342,7 +341,6 @@ public class Event {
      * @param eventPoster The new poster link
      */
     public void setEventPoster(String eventPoster) {
-        // FIXME: Need to think about how were going to upload images sicne they will be stored in Firestore
         this.eventPoster = eventPoster;
     }
 
@@ -454,6 +452,20 @@ public class Event {
             }
         }
         return waitlistCount;
+    }
+
+    /**
+     * This method will return the number of entrants in the event that are lost
+     * @return The number of waitlisted entrants
+     */
+    public Integer getNumberLost() {
+        Integer lostCount = 0;
+        for (int index = 0; index < entrants.size(); index++) {
+            if (entrants.get(index).getEntrantStatus().value.equals("lost")) {
+                lostCount++;
+            }
+        }
+        return lostCount;
     }
 
     /**

--- a/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/EventFragment.java
@@ -185,11 +185,12 @@ public class EventFragment extends Fragment implements DBOnCompleteListener<Even
                     lotteryButton.setTextColor(0xFF3A5983);
                     lotteryButton.setTextSize(20);
 
-                    // Update the status of the event to closed
-                    event.setEventStatus(Event.EventStatus.cancelled);
-
                     // Draw the lottery winners and change their statuses
                     drawWinners(event);
+                    setLoserStatuses(event);
+
+                    // Update the status of the event to closed
+                    event.setEventStatus(Event.EventStatus.cancelled);
 
                     // After the draw, update the event in the database
                     dbHandler.updateEvent(event, EventFragment.this::OnCompleteDB);
@@ -207,6 +208,7 @@ public class EventFragment extends Fragment implements DBOnCompleteListener<Even
 
                     // Redraw the lottery to fill all the available spots
                     drawWinners(event);
+                    setLoserStatuses(event);
 
                     // After the redraw, update the event in the database
                     dbHandler.updateEvent(event, EventFragment.this::OnCompleteDB);
@@ -280,26 +282,60 @@ public class EventFragment extends Fragment implements DBOnCompleteListener<Even
         Random rand = new Random();
         int winnerNumber = event.getCurrentWinners();
 
-        // Loop for how many winners this event wants (using winner count to keep check on it)
-        while (winnerNumber < event.getEventWinnersCount()) {
-            // Only try to draw applicants if there are entrants in the waitlist
-            if (event.getNumberWaitlisted() > 0) {
-                // Draw a random index number between 0 and the size of the list
-                int drawIndex = rand.nextInt(event.getEntrants().size());
-
-                if (!event.getEntrants().get(drawIndex).getEntrantStatus().value.equals("waitlisted")) {
-                    // This entrant does not have the status for a draw/redraw, so skip them
-                    continue;
+        if (event.getEventStatus().value.equals("ongoing")) {
+            // For initial draw
+            while (winnerNumber < event.getEventWinnersCount()) {
+                // Only try to draw applicants if there are entrants in the waitlist
+                if (event.getNumberWaitlisted() > 0) {
+                    // Draw a random index number between 0 and the size of the list
+                    int drawIndex = rand.nextInt(event.getEntrants().size());
+                    // Redrawing so deciding factor is the "lost" entrants
+                    if (!event.getEntrants().get(drawIndex).getEntrantStatus().value.equals("waitlisted")) {
+                        // This entrant does not have the status for a draw/redraw, so skip them
+                        continue;
+                    }
+                    // If we get here, then the entrant hasn't already been invited
+                    event.getEntrants().get(drawIndex).setEntrantStatus(Entrant.EntrantStatus.invited);
+                    winnerNumber++;
+                } else {
+                    // There are no entrants in the waitlist, so no need to draw anymore
+                    break;
                 }
-
-                // If we get here, then the entrant hasn't already been invited
-                event.getEntrants().get(drawIndex).setEntrantStatus(Entrant.EntrantStatus.invited);
-                winnerNumber++;
-            } else {
-                // There are no entrants in the waitlist, so no need to draw anymore
-                break;
             }
+        } else {
+            // For redraw
+            while (winnerNumber < event.getEventWinnersCount()) {
+                // Only try to draw applicants if there are entrants in the waitlist
+                if (event.getNumberLost() > 0) {
+                    // Draw a random index number between 0 and the size of the list
+                    int drawIndex = rand.nextInt(event.getEntrants().size());
+                    // Redrawing so deciding factor is the "lost" entrants
+                    if (!event.getEntrants().get(drawIndex).getEntrantStatus().value.equals("lost")) {
+                        // This entrant does not have the status for a draw/redraw, so skip them
+                        continue;
+                    }
+                    // If we get here, then the entrant hasn't already been invited
+                    event.getEntrants().get(drawIndex).setEntrantStatus(Entrant.EntrantStatus.invited);
+                    winnerNumber++;
+                } else {
+                    // There are no entrants in the waitlist, so no need to draw anymore
+                    break;
+                }
+            }
+        }
+    }
 
+    /**
+     * This method will go through the waitlist of an event and change all the entrants with
+     * "waitlist" status to "lost." Done after the lottery draw
+     * @param event The event that had its lottery drawn (the entrants we want to update)
+     */
+    public void setLoserStatuses(Event event) {
+        for (Integer index = 0; index < event.getEntrants().size(); index++) {
+            if (event.getEntrants().get(index).getEntrantStatus().value.equals("waitlisted")) {
+                // The entrant has waitlist status, so convert that to "lost"
+                event.getEntrants().get(index).setEntrantStatus(Entrant.EntrantStatus.lost);
+            }
         }
     }
 

--- a/app/src/main/java/com/example/pygmyhippo/organizer/ViewEntrantsFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/ViewEntrantsFragment.java
@@ -151,6 +151,7 @@ public class ViewEntrantsFragment extends Fragment implements DBOnCompleteListen
      */
     public void setUpStatusSpinner() {
         // Set up on click listeners for the spinner to filter the list
+        statusSpinner.setSelection(0);
         statusSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int position, long id) {

--- a/app/src/main/java/com/example/pygmyhippo/organizer/ViewSingleEntrantFragment.java
+++ b/app/src/main/java/com/example/pygmyhippo/organizer/ViewSingleEntrantFragment.java
@@ -70,6 +70,7 @@ public class ViewSingleEntrantFragment extends Fragment implements DBOnCompleteL
     private NavController navController;
 
     private boolean mapDimensionsGotten = false;     // A flag
+    private boolean canceledButtonPressed = false;
 
     private FrameLayout mapView;
     private FrameLayout mapMarker;
@@ -234,8 +235,12 @@ public class ViewSingleEntrantFragment extends Fragment implements DBOnCompleteL
         // TODO: Add settings for other statuses and provide more functionalities than just cancel
         if (status.equals("invited")) {
             // If the entrant is invited, then display the button to allow cancelling them
-            statusButton.setClickable(true);
-            statusButton.setVisibility(View.VISIBLE);
+            if (!canceledButtonPressed) {
+                // This is to prevent the layout listener from setting it off twice
+                statusButton.setClickable(true);
+                statusButton.setVisibility(View.VISIBLE);
+                canceledButtonPressed = true;
+            }
 
             // Set the listener so it'll change the status of the entrant to cancelled
             statusButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/res/layout/user_fragment_view_myevent.xml
+++ b/app/src/main/res/layout/user_fragment_view_myevent.xml
@@ -229,8 +229,7 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom = "3dp"
             android:textSize="12sp"
-            android:visibility="visible"
-            android:text="you are officially accepted into the event" />
+            android:visibility="visible"/>
 
 <!--        PENDING WAITLIST BUTTON -->
         <Button

--- a/app/src/test/java/com/example/pygmyhippo/Common/EntrantTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Common/EntrantTest.java
@@ -58,6 +58,18 @@ public class EntrantTest {
     }
 
     @Test
+    public void testSetEntrantStatusRejected() {
+        testEntrant.setEntrantStatus(Entrant.EntrantStatus.rejected);
+        assertEquals("rejected", testEntrant.getEntrantStatus().value);
+    }
+
+    @Test
+    public void testSetEntrantStatusLost() {
+        testEntrant.setEntrantStatus(Entrant.EntrantStatus.lost);
+        assertEquals("lost", testEntrant.getEntrantStatus().value);
+    }
+
+    @Test
     public void testLongitude() {
         assertEquals(null, testEntrant.getLongitude());
 

--- a/app/src/test/java/com/example/pygmyhippo/Common/EventTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Common/EventTest.java
@@ -349,6 +349,24 @@ public class EventTest {
     }
 
     @Test
+    public void testGetNumberLost() {
+        assertEquals(0, (int) testEvent.getNumberLost());
+
+        testEvent.addEntrant(new Entrant("account5", Entrant.EntrantStatus.lost));
+        assertEquals(1, (int) testEvent.getNumberLost());
+
+        testEvent.removeEntrant(new Entrant("account5", Entrant.EntrantStatus.lost));
+        assertEquals(0, (int) testEvent.getNumberLost());
+
+        testEvent.removeEntrant(new Entrant("account1", Entrant.EntrantStatus.invited));
+        assertEquals(0, (int) testEvent.getNumberLost());
+        testEvent.removeEntrant(new Entrant("account2", Entrant.EntrantStatus.waitlisted));
+        assertEquals(0, (int) testEvent.getNumberLost());
+        testEvent.removeEntrant(new Entrant("account3", Entrant.EntrantStatus.cancelled));
+        assertEquals(0, (int) testEvent.getNumberLost());
+    }
+
+    @Test
     public void testGetEntrant() {
         Entrant gottenEntrant = testEvent.getEntrant("account1");
         assertEquals("account1", gottenEntrant.getAccountID());

--- a/app/src/test/java/com/example/pygmyhippo/Organiser/EventFragmentTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Organiser/EventFragmentTest.java
@@ -34,7 +34,6 @@ public class EventFragmentTest {
                 new ArrayList<>(),
                 "The Swamp",
                 "2024-10-31",
-                // TODO: there is a bit of an issue with aligning the time when it is shorter on the xml
                 "4:00 PM MST - 4:00 AM MST",
                 "Love hippos and a party? Love a party! Join a party! We have lots of really cool hippos I'm sure you'd love to meet! There will be food, games, and all sorts of activities you could imagine! It's almost worth the price to see Moo Deng and his buddies!",
                 "$150.00",
@@ -141,6 +140,37 @@ public class EventFragmentTest {
     }
 
     @Test
+    public void testSetAllLosers() {
+        eventFragment.setLoserStatuses(testEvent);
+        int loserCount = 0;
+        for (int id = 0 ; id < 1000 ; id++) {
+            if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("lost")) {
+                loserCount++;
+            }
+        }
+
+        assertEquals(1000, loserCount);
+    }
+
+    @Test
+    public void testSetLosersAfterDraw() {
+        eventFragment.drawWinners(testEvent);
+        eventFragment.setLoserStatuses(testEvent);
+        int loserCount = 0;
+        int invitedCount = 0;
+        for (int id = 0 ; id < 1000 ; id++) {
+            if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("lost")) {
+                loserCount++;
+            } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("invited")) {
+                invitedCount++;
+            }
+        }
+
+        assertEquals(980, loserCount);
+        assertEquals(20, invitedCount);
+    }
+
+    @Test
     public void testRedraw() {
         // Set some invited
         for (int id = 0 ; id < 5 ; id++) {
@@ -157,28 +187,45 @@ public class EventFragmentTest {
             testEvent.getEntrants().get(id).setEntrantStatus(Entrant.EntrantStatus.cancelled);
         }
 
+        // Set some as rejected
+        for (int id = 20 ; id < 28 ; id++) {
+            testEvent.getEntrants().get(id).setEntrantStatus(Entrant.EntrantStatus.rejected);
+        }
+        // set the waitlisted to lost and event status to cancelled
+        testEvent.setEventStatus(Event.EventStatus.cancelled);
+        eventFragment.setLoserStatuses(testEvent);
+
         // Do the redraw
         eventFragment.drawWinners(testEvent);
 
         int invitedCount = 0;
-        int waitlistCount = 0;
+        int lostCount = 0;
         int cancelledCount = 0;
         int acceptedCount = 0;
+        int waitlistedCount = 0;
+        int rejectedCount = 0;
         for (int id = 0 ; id < 1000 ; id++) {
             if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("invited")) {
                 invitedCount++;
-            } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("waitlisted")) {
-                waitlistCount++;
+            } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("lost")) {
+                lostCount++;
             } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("cancelled")) {
                 cancelledCount++;
             } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("accepted")) {
                 acceptedCount++;
+            } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("waitlisted")) {
+                waitlistedCount++;
+            } else if (testEvent.getEntrants().get(id).getEntrantStatus().value.equals("rejected")) {
+                rejectedCount++;
             }
         }
 
         assertEquals(15, invitedCount);
         assertEquals(5, acceptedCount);
         assertEquals(10, cancelledCount);
-        assertEquals(970 , waitlistCount);
+        assertEquals(962 , lostCount);
+        assertEquals(8 , rejectedCount);
+        assertEquals(0, waitlistedCount);
+        assertEquals(1000, testEvent.getEntrants().size());
     }
 }

--- a/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
@@ -38,7 +38,7 @@ public class ViewEntrantsFragmentTest {
                 "Love hippos and a party? Love a party! Join a party! We have lots of really cool hippos I'm sure you'd love to meet! There will be food, games, and all sorts of activities you could imagine! It's almost worth the price to see Moo Deng and his buddies!",
                 "$150.00",
                 "hippoparty.png",
-                Event.EventStatus.ongoing,
+                Event.EventStatus.cancelled,
                 true);
         testEvent.setEventWinnersCount(20);
 
@@ -46,6 +46,8 @@ public class ViewEntrantsFragmentTest {
 
     @Test
     public void onlyWaitlistTest() {
+        testEvent.setEventStatus(Event.EventStatus.ongoing);
+
         // Fill the event with just waitlisted for now
         for (int id = 0 ; id < 150 ; id++) {
             String accountID = "account" + id;
@@ -55,7 +57,7 @@ public class ViewEntrantsFragmentTest {
 
         // Test when only entrants are the waitlisted ones
         ArrayList<Entrant> filterList = new ArrayList<Entrant>();
-        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
         assertEquals(150, filterList.size());
         // Check that they are all actually waitlisted
         for (int id = 0 ; id < 150 ; id++) {
@@ -83,7 +85,7 @@ public class ViewEntrantsFragmentTest {
 
         // Test when only entrants are the waitlisted ones
         ArrayList<Entrant> filterList = new ArrayList<Entrant>();
-        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
         assertEquals(0, filterList.size());
 
         filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
@@ -111,7 +113,7 @@ public class ViewEntrantsFragmentTest {
 
         // Test when only entrants are the waitlisted ones
         ArrayList<Entrant> filterList = new ArrayList<Entrant>();
-        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
         assertEquals(0, filterList.size());
 
         filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
@@ -139,7 +141,7 @@ public class ViewEntrantsFragmentTest {
 
         // Test when only entrants are the waitlisted ones
         ArrayList<Entrant> filterList = new ArrayList<Entrant>();
-        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
         assertEquals(0, filterList.size());
 
         filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
@@ -162,7 +164,7 @@ public class ViewEntrantsFragmentTest {
         int id = 0;
         for (id = 0 ; id < 5 ; id++) {
             String accountID = "account" + id;
-            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.waitlisted);
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.lost);
             testEvent.addEntrant(newEntrant);
         }
         for ( ; id < 11 ; id++) {
@@ -181,14 +183,14 @@ public class ViewEntrantsFragmentTest {
             testEvent.addEntrant(newEntrant);
         }
 
-        // Test when only entrants are the waitlisted ones
+        // Test when only entrants are the lost ones
         ArrayList<Entrant> filterList = new ArrayList<Entrant>();
-        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants());
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
         assertEquals(5, filterList.size());
 
-        // Check that they are all actually waitlisted
+        // Check that they are all actually lost
         for (id = 0 ; id < 5 ; id++) {
-            assertEquals("waitlisted", filterList.get(id).getEntrantStatus().value);
+            assertEquals("lost", filterList.get(id).getEntrantStatus().value);
         }
 
         filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());

--- a/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
+++ b/app/src/test/java/com/example/pygmyhippo/Organiser/ViewEntrantsFragmentTest.java
@@ -33,7 +33,6 @@ public class ViewEntrantsFragmentTest {
                 new ArrayList<>(),
                 "The Swamp",
                 "2024-10-31",
-                // TODO: there is a bit of an issue with aligning the time when it is shorter on the xml
                 "4:00 PM MST - 4:00 AM MST",
                 "Love hippos and a party? Love a party! Join a party! We have lots of really cool hippos I'm sure you'd love to meet! There will be food, games, and all sorts of activities you could imagine! It's almost worth the price to see Moo Deng and his buddies!",
                 "$150.00",
@@ -160,7 +159,8 @@ public class ViewEntrantsFragmentTest {
 
     @Test
     public void MixedStatusesTest() {
-        // Fill the event with just waitlisted for now
+        // Simulate mixed list once event is closed
+        testEvent.setEventStatus(Event.EventStatus.cancelled);
         int id = 0;
         for (id = 0 ; id < 5 ; id++) {
             String accountID = "account" + id;
@@ -180,6 +180,13 @@ public class ViewEntrantsFragmentTest {
         for ( ; id < 26 ; id++) {
             String accountID = "account" + id;
             Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.accepted);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Throw some rejected in there, they shouldn't show up in any of the filters
+        for ( ; id < 30 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.rejected);
             testEvent.addEntrant(newEntrant);
         }
 
@@ -215,5 +222,35 @@ public class ViewEntrantsFragmentTest {
         for (id = 0 ; id < 8 ; id++) {
             assertEquals("accepted", filterList.get(id).getEntrantStatus().value);
         }
+    }
+
+    @Test
+    public void testWaitlistOnClosedEvent() {
+        testEvent.setEventStatus(Event.EventStatus.cancelled);
+
+        // Fill the event with just lost for now
+        for (int id = 0 ; id < 150 ; id++) {
+            String accountID = "account" + id;
+            Entrant newEntrant = new Entrant(accountID, Entrant.EntrantStatus.lost);
+            testEvent.addEntrant(newEntrant);
+        }
+
+        // Test when only entrants should be in the waitlist filter (have lost status)
+        ArrayList<Entrant> filterList = new ArrayList<Entrant>();
+        filterList = viewEntrantsFragment.setEntrantWaitList(testEvent.getEntrants(), testEvent.getEventStatus().value);
+        assertEquals(150, filterList.size());
+        // Check that they are all actually lost
+        for (int id = 0 ; id < 150 ; id++) {
+            assertEquals("lost", filterList.get(id).getEntrantStatus().value);
+        }
+
+        filterList = viewEntrantsFragment.setEntrantInvited(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantCancelled(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
+
+        filterList = viewEntrantsFragment.setEntrantAccepted(testEvent.getEntrants());
+        assertEquals(0, filterList.size());
     }
 }


### PR DESCRIPTION
### Details:

- Drawing the lottery will set all entrants to either "invited" or "lost," "waitlist" status is now just used for open events
- The entrants in the "waitlist" filter in the entrants list is just the ones set to lost now
- Rejecting an invite just sets their status to "rejected" instead of "cancelled" They are still on the list but they won't actually show up in the Entrant List view. I think this is what we wanted but correct me if I'm wrong
- "cancelled" is only used now to for the entrants the organiser THEMSELVES cancelled. Entrants can't possibly make themselves cancelled
- When entrant declines to wait for redraw, the are just removed from the list

If I'm missing anything please make sure to point it out. Also if you have time try to play around with the draw and redrawing. I think I covered every possible scenario but I could have easily missed something :(

### CheckList:

- [x] StoryBoard (didn't need updates)
- [x] UML
- [x] Unit testing (updated)